### PR TITLE
Adjust TestModelAppTypeAssetMethods class declaration

### DIFF
--- a/marketplace/applications/tests/test_models.py
+++ b/marketplace/applications/tests/test_models.py
@@ -71,7 +71,7 @@ class TestModelAppTypeAsset(TestCase):
             create_app_type_asset(self.user)
 
 
-def TestModelAppTypeAssetMethods(TestCase):
+class TestModelAppTypeAssetMethods(TestCase):
     def setUp(self):
         super().setUp()
 


### PR DESCRIPTION
The test class `TestModelAppTypeAssetMethods` was wrongly declared, this PR aims to correct.