### PR TITLE
Adjust create of WeniWebChat App

### DIFF
--- a/marketplace/core/types/channels/weni_web_chat/serializers.py
+++ b/marketplace/core/types/channels/weni_web_chat/serializers.py
@@ -6,4 +6,10 @@ class WeniWebChatSerializer(AppTypeBaseSerializer):
     class Meta:
         model = App
         fields = ("app_code", "uuid", "project_uuid", "platform", "config", "created_by", "created_on", "modified_by")
-        read_only_fields = ("app_code", "uuid")
+        read_only_fields = ("app_code", "uuid", "platform")
+
+    def create(self, validated_data):
+        from .type import WeniWebChatType
+
+        validated_data["platform"] = WeniWebChatType.platform
+        return super().create(validated_data)

--- a/marketplace/core/types/channels/weni_web_chat/tests/test_views.py
+++ b/marketplace/core/types/channels/weni_web_chat/tests/test_views.py
@@ -53,18 +53,18 @@ class RetrieveWeniWebChatAppTestCase(APIBaseTestCase):
             app_code="wwc", created_by=self.user, project_uuid=str(uuid.uuid4()), platform=App.PLATFORM_WENI_FLOWS
         )
 
-        self.url = reverse("wwc-app-detail", kwargs={"pk": self.app.pk})
+        self.url = reverse("wwc-app-detail", kwargs={"uuid": self.app.uuid})
 
     @property
     def view(self):
         return self.view_class.as_view(APIBaseTestCase.ACTION_RETRIEVE)
 
     def test_request_ok(self):
-        response = self.request.get(self.url, pk=self.app.pk)
+        response = self.request.get(self.url, uuid=self.app.uuid)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_retrieve_app_data(self):
-        response = self.request.get(self.url, pk=self.app.pk)
+        response = self.request.get(self.url, uuid=self.app.uuid)
         self.assertIn("uuid", response.json)
         self.assertIn("project_uuid", response.json)
         self.assertIn("platform", response.json)

--- a/marketplace/core/types/channels/weni_web_chat/tests/test_views.py
+++ b/marketplace/core/types/channels/weni_web_chat/tests/test_views.py
@@ -15,10 +15,7 @@ class CreateWeniWebChatAppTestCase(APIBaseTestCase):
     def setUp(self):
         super().setUp()
 
-        self.body = {
-            "project_uuid": str(uuid.uuid4()),
-            "platform": App.PLATFORM_WENI_FLOWS,
-        }
+        self.body = {"project_uuid": str(uuid.uuid4())}
 
     @property
     def view(self):
@@ -35,12 +32,9 @@ class CreateWeniWebChatAppTestCase(APIBaseTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("project_uuid", response.json)
 
-    def test_create_app_without_platform(self):
-        self.body.pop("platform")
+    def test_create_app_platform(self):
         response = self.request.post(self.url, self.body)
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("platform", response.json)
+        self.assertEqual(response.json["platform"], App.PLATFORM_WENI_FLOWS)
 
 
 class RetrieveWeniWebChatAppTestCase(APIBaseTestCase):

--- a/marketplace/core/types/channels/weni_web_chat/views.py
+++ b/marketplace/core/types/channels/weni_web_chat/views.py
@@ -9,6 +9,7 @@ class WeniWebChatViewSet(viewsets.ModelViewSet):
 
     queryset = App.objects
     serializer_class = WeniWebChatSerializer
+    lookup_field = "uuid"
 
     def get_queryset(self):
         return super().get_queryset().filter(app_code=type_.WeniWebChatType.code)


### PR DESCRIPTION
Main changes:
- Change `WeniWebChatViewSet.lookup_field` to `uuid`
- On create a new WeniWebChat App will add automatically the platform field